### PR TITLE
Managed storage cleanup

### DIFF
--- a/core/src/com/cloud/storage/template/HttpTemplateDownloader.java
+++ b/core/src/com/cloud/storage/template/HttpTemplateDownloader.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Date;
 
 import org.apache.cloudstack.utils.imagestore.ImageStoreUtil;
@@ -117,7 +116,7 @@ public class HttpTemplateDownloader extends ManagedContextRunnable implements Te
             request = new GetMethod(downloadUrl);
             request.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, myretryhandler);
             completionCallback = callback;
-            //this.request.setFollowRedirects(false);
+            this.request.setFollowRedirects(true);
 
             File f = File.createTempFile("dnld", "tmp_", new File(toDir));
 
@@ -232,8 +231,7 @@ public class HttpTemplateDownloader extends ManagedContextRunnable implements Te
                 remoteSize = maxTemplateSizeInBytes;
             }
 
-            URL url = new URL(getDownloadUrl());
-            InputStream in = url.openStream();
+            InputStream in = request.getResponseBodyAsStream();
 
             RandomAccessFile out = new RandomAccessFile(file, "rw");
             out.seek(localFileSize);

--- a/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
@@ -1231,9 +1231,9 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 } else if (cmd instanceof PingCommand) {
                     logD = false;
                     s_logger.debug("Ping from " + hostId + "(" + hostName + ")");
-                    s_logger.trace("SeqA " + attache.getId() + "-" + request.getSequence() + ": Processing " + request);
+                    s_logger.trace("SeqA " + hostId + "-" + request.getSequence() + ": Processing " + request);
                 } else {
-                    s_logger.debug("SeqA " + attache.getId() + "-" + request.getSequence() + ": Processing " + request);
+                    s_logger.debug("SeqA " + hostId + "-" + request.getSequence() + ": Processing " + request);
                 }
             }
 

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3355,7 +3355,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         }
 
         if (fromHost.getClusterId().longValue() != dest.getCluster().getId()) {
-            s_logger.info("Source and destination host are not in same cluster, unable to migrate to host: " + dest.getHost().getId());
+            s_logger.info("Source and destination host are not in same cluster, unable to migrate to host: " + dstHostId);
             throw new CloudRuntimeException("Source and destination host are not in same cluster, unable to migrate to host: " + dest.getHost().getId());
         }
 

--- a/engine/orchestration/test/com/cloud/agent/manager/AgentManagerImplTest.java
+++ b/engine/orchestration/test/com/cloud/agent/manager/AgentManagerImplTest.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.agent.manager;
+
+import com.cloud.agent.Listener;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ReadyCommand;
+import com.cloud.agent.api.StartupCommand;
+import com.cloud.agent.api.StartupRoutingCommand;
+import com.cloud.exception.ConnectionException;
+import com.cloud.host.HostVO;
+import com.cloud.host.Status;
+import com.cloud.host.dao.HostDao;
+import com.cloud.utils.Pair;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+public class AgentManagerImplTest {
+
+    private HostDao hostDao;
+    private Listener storagePoolMonitor;
+    private AgentAttache attache;
+    private AgentManagerImpl mgr = Mockito.spy(new AgentManagerImpl());
+    private HostVO host;
+    private StartupCommand[] cmds;
+
+    @Before
+    public void setUp() throws Exception {
+        host = new HostVO("some-Uuid");
+        host.setDataCenterId(1L);
+        cmds = new StartupCommand[]{new StartupRoutingCommand()};
+        attache = new ConnectedAgentAttache(null, 1L, "kvm-attache", null, false);
+
+        hostDao = Mockito.mock(HostDao.class);
+        storagePoolMonitor = Mockito.mock(Listener.class);
+
+        mgr._hostDao = hostDao;
+        mgr._hostMonitors = new ArrayList<>();
+        mgr._hostMonitors.add(new Pair<>(0, storagePoolMonitor));
+    }
+
+    @Test
+    public void testNotifyMonitorsOfConnectionNormal() throws ConnectionException {
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
+        Mockito.doNothing().when(storagePoolMonitor).processConnect(Mockito.eq(host), Mockito.eq(cmds[0]), Mockito.eq(false));
+        Mockito.doReturn(true).when(mgr).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.any(Status.Event.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.doReturn(Mockito.mock(Answer.class)).when(mgr).easySend(Mockito.anyLong(), Mockito.any(ReadyCommand.class));
+        Mockito.doReturn(true).when(mgr).agentStatusTransitTo(Mockito.eq(host), Mockito.eq(Status.Event.Ready), Mockito.anyLong());
+
+        final AgentAttache agentAttache = mgr.notifyMonitorsOfConnection(attache, cmds, false);
+        Assert.assertTrue(agentAttache.isReady()); // Agent is in UP state
+    }
+
+    @Test
+    public void testNotifyMonitorsOfConnectionWhenStoragePoolConnectionHostFailure() throws ConnectionException {
+        ConnectionException connectionException = new ConnectionException(true, "storage pool could not be connected on host");
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
+        Mockito.doThrow(connectionException).when(storagePoolMonitor).processConnect(Mockito.eq(host), Mockito.eq(cmds[0]), Mockito.eq(false));
+        Mockito.doReturn(true).when(mgr).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.any(Status.Event.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        try {
+            mgr.notifyMonitorsOfConnection(attache, cmds, false);
+            Assert.fail("Connection Exception was expected");
+        } catch (ConnectionException e) {
+            Assert.assertEquals(e.getMessage(), connectionException.getMessage());
+        }
+        Mockito.verify(mgr, Mockito.times(1)).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.eq(Status.Event.AgentDisconnected), Mockito.eq(true), Mockito.eq(true));
+    }
+}

--- a/packaging/centos63/cloud-agent.rc
+++ b/packaging/centos63/cloud-agent.rc
@@ -26,6 +26,7 @@
 
 # set environment variables
 
+TMP=/usr/share/cloudstack-agent/tmp
 SHORTNAME=$(basename $0 | sed -e 's/^[SK][0-9][0-9]//')
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
@@ -40,6 +41,9 @@ if [ -z "$JSVC" ]; then
     echo no jsvc found in path;
     exit 1;
 fi
+
+# create java tmp dir if not found
+mkdir -m 0755 -p "$TMP"
 
 unset OPTIONS
 [ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
@@ -64,7 +68,7 @@ export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/a
 start() {
     echo -n $"Starting $PROGNAME: "
     if hostname --fqdn >/dev/null 2>&1 ; then
-        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+        $JSVC -Djava.io.tmpdir="$TMP" -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
             -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
         RETVAL=$?
         echo

--- a/packaging/debian/cloudstack-agent.init
+++ b/packaging/debian/cloudstack-agent.init
@@ -33,6 +33,7 @@
 
 . /lib/lsb/init-functions
 
+TMP=/usr/share/cloudstack-agent/tmp
 SHORTNAME="cloudstack-agent"
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
@@ -44,6 +45,9 @@ SHUTDOWN_WAIT="30"
 
 unset OPTIONS
 [ -r /etc/default/"$SHORTNAME" ] && source /etc/default/"$SHORTNAME"
+
+# create java tmp dir if not found
+mkdir -m 0755 -p "$TMP"
 
 # The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
 JDK_DIRS="/usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
@@ -96,7 +100,7 @@ start() {
 
     wait_for_network
 
-    if start_daemon -p $PIDFILE $DAEMON -Xms256m -Xmx2048m -cp "$CLASSPATH" -Djna.nosys=true -pidfile "$PIDFILE" -errfile SYSLOG $CLASS
+    if start_daemon -p $PIDFILE $DAEMON -Djava.io.tmpdir="$TMP" -Xms256m -Xmx2048m -cp "$CLASSPATH" -Djna.nosys=true -pidfile "$PIDFILE" -errfile SYSLOG $CLASS
         RETVAL=$?
     then
         rc=0

--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -27,7 +27,7 @@ EnvironmentFile=-/etc/default/cloudstack-agent
 ExecStart=/bin/sh -ec '\
     export ACP=`ls /usr/share/cloudstack-agent/lib/*.jar /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null|tr "\\n" ":"`; \
     export CLASSPATH="$ACP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"; \
-    mkdir -m 0755 -p ${JAVA_TMPDIR} \
+    mkdir -m 0755 -p ${JAVA_TMPDIR}; \
     ${JAVA} -Djava.io.tmpdir="${JAVA_TMPDIR}" -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
 Restart=always
 RestartSec=10s

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/KVMHAChecker.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/KVMHAChecker.java
@@ -57,7 +57,7 @@ public class KVMHAChecker extends KVMHABase implements Callable<Boolean> {
             s_logger.debug("reture: " + result);
             s_logger.debug("parser: " + parser.getLine());
             if (result == null && parser.getLine().contains("> DEAD <")) {
-                s_logger.debug("read heartbeat failed: " + result);
+                s_logger.debug("read heartbeat failed: ");
                 results.add(false);
             } else {
                 results.add(true);

--- a/plugins/network-elements/juniper-contrail/pom.xml
+++ b/plugins/network-elements/juniper-contrail/pom.xml
@@ -83,6 +83,17 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-utils</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+           <artifactId>xml-apis</artifactId>
+           <groupId>xml-apis</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-framework-spring-lifecycle</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/EventUtils.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/EventUtils.java
@@ -28,8 +28,8 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.framework.messagebus.MessageBus;
-import org.apache.cloudstack.framework.messagebus.MessageBusBase;
+import org.apache.cloudstack.framework.events.EventBus;
+import org.apache.cloudstack.framework.events.EventBusException;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -46,7 +46,7 @@ import com.cloud.utils.component.ComponentMethodInterceptor;
 public class EventUtils {
     private static final Logger s_logger = Logger.getLogger(EventUtils.class);
 
-    protected static MessageBus s_messageBus = null;
+    protected static  EventBus s_eventBus = null;
 
     public EventUtils() {
     }
@@ -58,9 +58,9 @@ public class EventUtils {
         }
 
         try {
-            s_messageBus = ComponentContext.getComponent(MessageBusBase.class);
+            s_eventBus = ComponentContext.getComponent(EventBus.class);
         } catch (NoSuchBeanDefinitionException nbe) {
-            return; // no provider is configured to provide events bus, so just return
+             return; // no provider is configured to provide events bus, so just return
         }
 
         org.apache.cloudstack.framework.events.Event event =
@@ -72,9 +72,10 @@ public class EventUtils {
         eventDescription.put("details", details);
         event.setDescription(eventDescription);
         try {
-            s_messageBus.publish(EventTypes.getEntityForEvent(eventType), eventType, null, event);
-        } catch (Exception e) {
-            s_logger.warn("Failed to publish action event on the the event bus.");
+            s_eventBus.publish(event);
+        } catch (EventBusException evx) {
+            String errMsg = "Failed to publish contrail event.";
+            s_logger.warn(errMsg, evx);
         }
 
     }

--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -493,6 +493,7 @@ def default_network_rules(vm_name, vm_id, vm_ip, vm_mac, vif, brname, sec_ips):
         if vm_ip is not None:
             execute("iptables -A " + vmchain_default + " -m physdev --physdev-is-bridged --physdev-in " + vif + " -m set ! --set " + vmipsetName + " src -j DROP")
             execute("iptables -A " + vmchain_default + " -m physdev --physdev-is-bridged --physdev-in " + vif + " -m set --set " + vmipsetName + " src -p udp --dport 53  -j RETURN ")
+            execute("iptables -A " + vmchain_default + " -m physdev --physdev-is-bridged --physdev-in " + vif + " -m set --set " + vmipsetName + " src -p tcp --dport 53  -j RETURN ")
             execute("iptables -A " + vmchain_default + " -m physdev --physdev-is-bridged --physdev-in " + vif + " -m set --set " + vmipsetName + " src -j " + vmchain_egress)
         execute("iptables -A " + vmchain_default + " -m physdev --physdev-is-bridged --physdev-out " + vif + " -j " + vmchain)
         execute("iptables -A " + vmchain + " -j DROP")

--- a/server/src/com/cloud/storage/listener/StoragePoolMonitor.java
+++ b/server/src/com/cloud/storage/listener/StoragePoolMonitor.java
@@ -99,12 +99,14 @@ public class StoragePoolMonitor implements Listener {
                     }
 
                     Long hostId = host.getId();
-                    s_logger.debug("Host " + hostId + " connected, sending down storage pool information ...");
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("Host " + hostId + " connected, connecting host to shared pool id " + pool.getId() + " and sending storage pool information ...");
+                    }
                     try {
                         _storageManager.connectHostToSharedPool(hostId, pool.getId());
                         _storageManager.createCapacityEntry(pool.getId());
                     } catch (Exception e) {
-                        s_logger.warn("Unable to connect host " + hostId + " to pool " + pool + " due to " + e.toString(), e);
+                        throw new ConnectionException(true, "Unable to connect host " + hostId + " to storage pool id " + pool.getId() + " due to " + e.toString(), e);
                     }
                 }
             }

--- a/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -390,9 +390,10 @@ public class SnapshotManagerImpl extends ManagerBase implements SnapshotManager,
         SnapshotVO snapshot = _snapshotDao.findById(snapshotId);
         if (policyId != Snapshot.MANUAL_POLICY_ID) {
             SnapshotScheduleVO snapshotSchedule = _snapshotScheduleDao.getCurrentSchedule(volumeId, policyId, true);
-            assert snapshotSchedule != null;
-            snapshotSchedule.setSnapshotId(snapshotId);
-            _snapshotScheduleDao.update(snapshotSchedule.getId(), snapshotSchedule);
+            if (snapshotSchedule !=null) {
+                snapshotSchedule.setSnapshotId(snapshotId);
+                _snapshotScheduleDao.update(snapshotSchedule.getId(), snapshotSchedule);
+            }
         }
 
         if (snapshot != null && snapshot.isRecursive()) {

--- a/server/src/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/com/cloud/user/AccountManagerImpl.java
@@ -2231,12 +2231,16 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     @DB
     @ActionEvent(eventType = EventTypes.EVENT_REGISTER_FOR_SECRET_API_KEY, eventDescription = "register for the developer API keys")
     public String[] createApiKeyAndSecretKey(RegisterCmd cmd) {
+        Account caller = CallContext.current().getCallingAccount();
         final Long userId = cmd.getId();
 
         User user = getUserIncludingRemoved(userId);
         if (user == null) {
             throw new InvalidParameterValueException("unable to find user by id");
         }
+
+        Account account = _accountDao.findById(user.getAccountId());
+        checkAccess(caller, null, true, account);
 
         // don't allow updating system user
         if (user.getId() == User.UID_SYSTEM) {

--- a/server/test/com/cloud/storage/listener/StoragePoolMonitorTest.java
+++ b/server/test/com/cloud/storage/listener/StoragePoolMonitorTest.java
@@ -46,7 +46,7 @@ public class StoragePoolMonitorTest {
         storageManager = Mockito.mock(StorageManagerImpl.class);
         poolDao = Mockito.mock(PrimaryDataStoreDao.class);
 
-        storagePoolMonitor = new StoragePoolMonitor(storageManager, poolDao);
+        storagePoolMonitor = new StoragePoolMonitor(storageManager, poolDao, null);
         host = new HostVO("some-uuid");
         pool = new StoragePoolVO();
         pool.setScope(ScopeType.CLUSTER);

--- a/server/test/com/cloud/storage/listener/StoragePoolMonitorTest.java
+++ b/server/test/com/cloud/storage/listener/StoragePoolMonitorTest.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.storage.listener;
+
+import com.cloud.agent.api.StartupRoutingCommand;
+import com.cloud.exception.ConnectionException;
+import com.cloud.exception.StorageUnavailableException;
+import com.cloud.host.HostVO;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.ScopeType;
+import com.cloud.storage.StorageManagerImpl;
+import com.cloud.storage.StoragePoolStatus;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class StoragePoolMonitorTest {
+
+    private StorageManagerImpl storageManager;
+    private PrimaryDataStoreDao poolDao;
+    private StoragePoolMonitor storagePoolMonitor;
+    private HostVO host;
+    private StoragePoolVO pool;
+    private StartupRoutingCommand cmd;
+
+    @Before
+    public void setUp() throws Exception {
+        storageManager = Mockito.mock(StorageManagerImpl.class);
+        poolDao = Mockito.mock(PrimaryDataStoreDao.class);
+
+        storagePoolMonitor = new StoragePoolMonitor(storageManager, poolDao);
+        host = new HostVO("some-uuid");
+        pool = new StoragePoolVO();
+        pool.setScope(ScopeType.CLUSTER);
+        pool.setStatus(StoragePoolStatus.Up);
+        pool.setId(123L);
+        cmd = new StartupRoutingCommand();
+        cmd.setHypervisorType(Hypervisor.HypervisorType.KVM);
+    }
+
+    @Test
+    public void testProcessConnectStoragePoolNormal() throws Exception {
+        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+
+        storagePoolMonitor.processConnect(host, cmd, false);
+
+        Mockito.verify(storageManager, Mockito.times(1)).connectHostToSharedPool(Mockito.eq(host.getId()), Mockito.eq(pool.getId()));
+        Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(Mockito.eq(pool.getId()));
+    }
+
+    @Test(expected = ConnectionException.class)
+    public void testProcessConnectStoragePoolFailureOnHost() throws Exception {
+        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.doThrow(new StorageUnavailableException("unable to mount storage", 123L)).when(storageManager).connectHostToSharedPool(Mockito.anyLong(), Mockito.anyLong());
+
+        storagePoolMonitor.processConnect(host, cmd, false);
+    }
+}

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -359,6 +359,10 @@ class CsIP:
                         "-m state --state RELATED,ESTABLISHED " +
                         "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
 
+        self.fw.append(["mangle", "front",
+                        "-A POSTROUTING " +
+                        "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
+
         if self.get_type() in ["public"]:
             self.fw.append(["mangle", "front",
                             "-A PREROUTING " +
@@ -375,9 +379,6 @@ class CsIP:
                             "-A VPN_%s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.address['public_ip']])
             self.fw.append(["mangle", "",
                             "-A VPN_%s -j RETURN" % self.address['public_ip']])
-            self.fw.append(["mangle", "front",
-                            "-A POSTROUTING " +
-                            "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
             self.fw.append(["nat", "",
                             "-A POSTROUTING -o eth2 -j SNAT --to-source %s" % self.address['public_ip']])
             self.fw.append(["mangle", "",
@@ -453,6 +454,8 @@ class CsIP:
                 ["mangle", "front", "-A ACL_OUTBOUND_%s -d 224.0.0.18/32 -j ACCEPT" % self.dev])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p udp -m udp --dport 67 -j ACCEPT" % self.dev])
+            self.fw.append(
+                ["mangle", "front", "-A POSTROUTING " + "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p udp -m udp --dport 53 -s %s -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(

--- a/systemvm/patches/debian/config/opt/cloud/bin/getRouterAlerts.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/getRouterAlerts.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# getRouterAlerts.sh  --- Send the alerts from routerServiceMonitor.log to Management Server
+
+#set -x
+
+filename=/var/log/routerServiceMonitor.log #Monitor service log file
+if [ -n "$1" -a -n "$2" ]
+then
+        reqDateVal=$(date -d "$1 $2" "+%s");
+else
+        reqDateVal=0
+fi
+if [ -f $filename ]
+then
+        while read line
+        do
+            if [ -n "$line" ]
+            then
+                dateval=`echo $line |awk '{print $1, $2}'`
+                IFS=',' read -a array <<< "$dateval"
+                dateval=${array[0]}
+
+                toDateVal=$(date -d "$dateval" "+%s")
+
+                if [ "$toDateVal" -gt "$reqDateVal" ]
+                then
+                    alerts="$line\n$alerts"
+                else
+                    break
+                fi
+            fi
+        done < <(tac $filename)
+fi
+if [ -n "$alerts" ]; then
+       echo $alerts
+else
+       echo "No Alerts"
+fi

--- a/test/integration/component/test_accounts.py
+++ b/test/integration/component/test_accounts.py
@@ -1531,6 +1531,167 @@ class TestUserLogin(cloudstackTestCase):
         return
 
 
+class TestUserAPIKeys(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.testClient = super(TestUserAPIKeys, cls).getClsTestClient()
+        cls.api_client = cls.testClient.getApiClient()
+
+        cls.services = Services().services
+        cls.domain = get_domain(cls.api_client)
+        cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+        # Create an account, domain etc
+        cls.domain = Domain.create(
+            cls.api_client,
+            cls.services["domain"],
+        )
+        cls.account = Account.create(
+            cls.api_client,
+            cls.services["account"],
+            admin=False,
+            domainid=cls.domain.id
+        )
+        cls.domain_2 = Domain.create(
+            cls.api_client,
+            cls.services["domain"],
+        )
+        cls.account_2 = Account.create(
+            cls.api_client,
+            cls.services["account"],
+            admin=False,
+            domainid=cls.domain_2.id
+        )
+        cls._cleanup = [
+            cls.account,
+            cls.domain,
+            cls.account_2,
+            cls.domain_2
+        ]
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            # Cleanup resources used
+            cleanup_resources(cls.api_client, cls._cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.dbclient = self.testClient.getDbConnection()
+        self.cleanup = []
+        return
+
+    def tearDown(self):
+        try:
+            # Clean up, terminate the created network offerings
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    @attr(tags=[
+        "role",
+        "accounts",
+        "simulator",
+        "advanced",
+        "advancedns",
+        "basic",
+        "eip",
+        "sg"
+    ])
+    def test_user_key_renew_same_account(self):
+        # Create an User associated with the account
+        user_1 = User.create(
+            self.apiclient,
+            self.services["user"],
+            account=self.account.name,
+            domainid=self.domain.id
+        )
+        self.cleanup.append(user_1)
+        account_response = list_accounts(
+            self.apiclient,
+            id=self.account.id
+        )[0]
+        self.assertEqual(
+            hasattr(account_response, 'user'),
+            True,
+            "Users are included in account response")
+
+        account_users = account_response.user
+        self.assertEqual(
+            isinstance(account_users, list),
+            True,
+            "Check account for valid data"
+        )
+        self.assertNotEqual(
+            len(account_users),
+            0,
+            "Check number of User in Account")
+        [user] = [u for u in account_users if u.username == user_1.username]
+        self.assertEqual(
+            user.apikey,
+            None,
+            "Check that the user don't have an API key yet")
+
+        self.debug("Register API keys for user")
+        userkeys = User.registerUserKeys(self.apiclient, user_1.id)
+        users = list_accounts(
+            self.apiclient,
+            id=self.account.id
+        )[0].user
+        [user] = [u for u in users if u.id == user_1.id]
+        self.assertEqual(
+            user.apikey,
+            userkeys.apikey,
+            "Check User api key")
+        self.assertEqual(
+            user.secretkey,
+            userkeys.secretkey,
+            "Check User having secret key")
+
+        self.debug("Get test client with user keys")
+        cs_api = self.testClient.getUserApiClient(
+            UserName=self.account.name,
+            DomainName=self.account.domain)
+        self.debug("Renew API keys for user using current keys")
+        new_keys = User.registerUserKeys(cs_api, user_1.id)
+        self.assertNotEqual(
+            userkeys.apikey,
+            new_keys.apikey,
+            "Check API key is different")
+        self.assertNotEqual(
+            userkeys.secretkey,
+            new_keys.secretkey,
+            "Check secret key is different")
+
+    @attr(tags=[
+        "role",
+        "accounts",
+        "simulator",
+        "advanced",
+        "advancedns",
+        "basic",
+        "eip",
+        "sg"
+    ])
+    def test_user_cannot_renew_other_keys(self):
+        cs_api = self.testClient.getUserApiClient(
+            UserName=self.account.name,
+            DomainName=self.account.domain)
+        self.debug("Try to change API key of an account in another domain")
+        users = list_accounts(
+            self.apiclient,
+            id=self.account_2.id
+        )[0].user
+        with self.assertRaises(CloudstackAPIException) as e:
+            User.registerUserKeys(cs_api, users[0].id)
+
+
 class TestDomainForceRemove(cloudstackTestCase):
 
     @classmethod


### PR DESCRIPTION
When deleting a managed volume that was never attached, Cloudstack is not deleting the volume created on the backend. This is because Cloudstack checks the `path` which is only set when the volume is attached. However, in case of managed storage, a backend volume can exist without the `path` being populated. 