### PR TITLE
Fixes for object store as secondary store for SAN assisted snapshots

### DIFF
--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -413,6 +413,12 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
                 copyCmdAnswer = (CopyCmdAnswer)_agentMgr.send(hostVO.getId(), copyCommand);
 
+                if (!copyCmdAnswer.getResult()) {
+                    // We were not able to copy, deal with it
+                    errMsg = copyCmdAnswer.getDetails();
+                    throw  new CloudRuntimeException(errMsg);
+                }
+
                 if (needCache) {
                     // If cached storage was needed (in case of object store as secondary
                     // storage), at this point, the data has been copied from the primary
@@ -450,6 +456,9 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
                     if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
                         errMsg = copyCmdAnswer.getDetails();
+                        if(needCache) {
+                            cacheMgr.deleteCacheObject(destOnStore);
+                        }
                     }
                     else {
                         errMsg = "Unable to create template from snapshot";

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -543,6 +543,10 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                     if (snapshotSr != null) {
                         hypervisorResource.removeSR(conn, snapshotSr);
                     }
+
+                    if (primaryStore.isManaged()) {
+                        hypervisorResource.removeSR(conn, primaryStorageSR);
+                    }
                 }
             } else {
                 final String primaryStorageSRUuid = primaryStorageSR.getUuid(conn);
@@ -719,9 +723,10 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
         }
         SR srcSr = null;
         VDI destVdi = null;
-        try {
-            SR primaryStorageSR;
 
+        SR primaryStorageSR = null;
+
+        try {
             if (pool.isManaged()) {
                 Map<String,String> destDetails = cmd.getOptions2();
 
@@ -782,6 +787,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setPath(volumeUUID);
             newVol.setSize(vdir.virtualSize);
+
             return new CopyCmdAnswer(newVol);
         } catch (final Types.XenAPIException e) {
             details += " due to " + e.toString();
@@ -793,6 +799,11 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             if (srcSr != null) {
                 hypervisorResource.removeSR(conn, srcSr);
             }
+
+            if (pool.isManaged()) {
+                hypervisorResource.removeSR(conn, primaryStorageSR);
+            }
+
             if (!result && destVdi != null) {
                 try {
                     destVdi.destroy(conn);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -568,9 +568,10 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                     physicalSize = Long.parseLong(tmp[1]);
                     finalPath = folder + File.separator + snapshotBackupUuid + ".vhd";
                 }
+
+                final String volumeUuid = snapshotTO.getVolume().getPath();
+                destroySnapshotOnPrimaryStorageExceptThis(conn, volumeUuid, snapshotUuid);
             }
-            final String volumeUuid = snapshotTO.getVolume().getPath();
-            destroySnapshotOnPrimaryStorageExceptThis(conn, volumeUuid, snapshotUuid);
 
             final SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
             newSnapshot.setPath(finalPath);

--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -403,9 +403,10 @@ public class SolidFireUtil {
                 SolidFireUtil.getIqnsFromHosts(hosts), new long[] { sfVolumeId });
         }
         catch (Exception ex) {
-            String iqnInVagAlready = "Exceeded maximum number of Volume Access Groups per initiator";
+            String iqnInVagAlready1 = "Exceeded maximum number of Volume Access Groups per initiator";
+            String iqnInVagAlready2 = "Exceeded maximum number of VolumeAccessGroups per Initiator";
 
-            if (!ex.getMessage().contains(iqnInVagAlready)) {
+            if (!ex.getMessage().contains(iqnInVagAlready1) && !ex.getMessage().contains(iqnInVagAlready2)) {
                 throw new CloudRuntimeException(ex.getMessage());
             }
 

--- a/test/integration/plugins/solidfire/TestManagedSystemVMs.py
+++ b/test/integration/plugins/solidfire/TestManagedSystemVMs.py
@@ -488,7 +488,9 @@ class TestManagedSystemVMs(cloudstackTestCase):
                 type="Routing"
             )
 
-            sf_util.check_kvm_access_to_volume(sf_root_volume.iqn, list_hosts_response, self.testdata[TestData.kvm], self, False)
+            kvm_login = self.testdata[TestData.kvm]
+
+            sf_util.check_kvm_access_to_volume(sf_root_volume.iqn, list_hosts_response, kvm_login[TestData.username], kvm_login[TestData.password], self, False)
         else:
             self.assertTrue(False, "Invalid hypervisor type")
 
@@ -544,7 +546,9 @@ class TestManagedSystemVMs(cloudstackTestCase):
                     type="Routing"
                 )
 
-                sf_util.check_kvm_access_to_volume(sf_root_volume.iqn, list_hosts_response, self.testdata[TestData.kvm], self)
+                kvm_login = self.testdata[TestData.kvm]
+
+                sf_util.check_kvm_access_to_volume(sf_root_volume.iqn, list_hosts_response, kvm_login[TestData.username], kvm_login[TestData.password], self)
             else:
                 self.assertTrue(False, "Invalid hypervisor type")
 

--- a/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
+++ b/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
@@ -39,7 +39,7 @@ from marvin.lib.utils import cleanup_resources
 # Prerequisites:
 #  Only one zone
 #  Only one pod
-#  Two clusters
+#  Two clusters (have system VMs (including the VR) running on local or NFS storage)
 
 
 class TestData():

--- a/test/integration/plugins/solidfire/util/sf_util.py
+++ b/test/integration/plugins/solidfire/util/sf_util.py
@@ -155,11 +155,11 @@ def check_xen_sr(xen_sr_name, xen_session, obj_assert, should_exist=True):
     else:
         check_list(xen_sr, 0, obj_assert, "SR " + xen_sr_name + " exists, but shouldn't.")
 
-def check_kvm_access_to_volume(iscsi_name, kvm_hosts, kvm_login, obj_assert, should_exist=True):
+def check_kvm_access_to_volume(iscsi_name, kvm_hosts, username, password, obj_assert, should_exist=True):
     count = 0
 
     for kvm_host in kvm_hosts:
-        ssh_connection = sf_util.get_ssh_connection(kvm_host.ipaddress, kvm_login[TestData.username], kvm_login[TestData.password])
+        ssh_connection = get_ssh_connection(kvm_host.ipaddress, username, password)
 
         stdin, stdout, stderr = ssh_connection.exec_command("ls /dev/disk/by-path | grep " + iscsi_name)
 


### PR DESCRIPTION
These are couple of fixes that I have done with my testing with an object store as a secondary storage. Some of the code here also addresses common codepaths especially on the XenServer plugin.